### PR TITLE
修复在子项目情况下移动端导航问题，修复标签云字体颜色不可见问题

### DIFF
--- a/layout/_partial/left-col.ejs
+++ b/layout/_partial/left-col.ejs
@@ -10,7 +10,7 @@
         </a>
 
         <hgroup>
-          <h1 class="header-author"><a href="/"><%=theme.author%></a></h1>
+          <h1 class="header-author"><a href="<%- config.root %>"><%=theme.author%></a></h1>
         </hgroup>
 
         <% if (theme.subtitle){ %>

--- a/layout/_partial/mobile-nav.ejs
+++ b/layout/_partial/mobile-nav.ejs
@@ -1,11 +1,11 @@
 <nav id="mobile-nav">
       <div class="overlay">
           <div class="slider-trigger"></div>
-          <h1 class="header-author js-mobile-header hide"><a href="/" title="回到主页"><%=theme.author%></a></h1>
+          <h1 class="header-author js-mobile-header hide"><a href="<%- config.root %>" title="回到主页"><%=theme.author%></a></h1>
       </div>
     <div class="intrude-less">
         <header id="header" class="inner">
-            <a href="/" class="profilepic">
+            <a href="<%- config.root %>" class="profilepic">
                 <% if (theme.animate){ %>
                     <img lazy-src="<%- config.root %><%=theme.avatar%>" class="js-avatar">
                 <% } else { %>
@@ -13,7 +13,7 @@
                 <% } %>
             </a>
             <hgroup>
-              <h1 class="header-author"><a href="/" title="回到主页"><%=theme.author%></a></h1>
+              <h1 class="header-author"><a href="<%- config.root %>" title="回到主页"><%=theme.author%></a></h1>
             </hgroup>
             <% if (theme.subtitle){ %>
             <p class="header-subtitle"><%=theme.subtitle%></p>

--- a/layout/_partial/page.ejs
+++ b/layout/_partial/page.ejs
@@ -48,7 +48,7 @@
             amount: 999, 
             color: true, 
             start_color: 'gray', 
-            end_color: 'black',
+            end_color: 'whitesmoke',
         }) %>
     </div>
     <style>


### PR DESCRIPTION
1. 之前没有修改到子项目情况下，Mobile访问时导航不正确的问题，现在补上一起提交。
2. 标签云字体颜色不可见问题，由于主题是偏黑色，在Tag Cloud显示时设置的颜色是由Gray到Black，中间有一个颜色与主题背景的颜色类似，然后就看不到标签了，好像消失了，因此设置成灰色到偏白色的范围。
