### PR TITLE
change some url from http to https

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -1,4 +1,4 @@
-<%- js('http://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min') %>
+<%- js('https://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min') %>
 <%- js('js/main') %>
 <%- partial('_partial/background') %>
 <%- partial('analytics/google-analytics') %>

--- a/layout/_partial/hide-labels.ejs
+++ b/layout/_partial/hide-labels.ejs
@@ -1,6 +1,6 @@
 <% if (is_archive() || is_tag() || is_category()) { %>
     <button class="hide-labels">TAG 开关</button>
-    <script src="http://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min.js">
+    <script src="https://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min.js">
     </script>
     <script>
         $(document).ready(function() {

--- a/layout/_partial/mathjax.ejs
+++ b/layout/_partial/mathjax.ejs
@@ -15,5 +15,5 @@ MathJax.Hub.Queue(function() {
 });
 </script>
 
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>

--- a/layout/_partial/page.ejs
+++ b/layout/_partial/page.ejs
@@ -99,7 +99,7 @@
     </style>
 
     <!-- Count tags and categories -->
-    <script src="http://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min.js"></script>
+    <script src="https://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min.js"></script>
     <p id="count">
             已有<span><script>document.write($(".category-list-item").length)</script></span>个分类，
             共计<span><script>document.write($(".tags > a").length)</script></span>个标签。

--- a/layout/_partial/post-nav-button.ejs
+++ b/layout/_partial/post-nav-button.ejs
@@ -17,7 +17,7 @@
         <% } %>
     </div>
     <%- list_posts({amount: 999}) %>
-    <script src="http://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min.js"></script>
+    <script src="https://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min.js"></script>
     <script>
         $(".post-list").addClass("toc-article");
         $(".post-list-item a").attr("target","_blank");

--- a/layout/_partial/toc.ejs
+++ b/layout/_partial/toc.ejs
@@ -4,7 +4,7 @@
 </div>
 <input type="button" id="tocButton" value="隐藏目录"  title="点击按钮隐藏或者显示文章目录">
 
-<%- js('http://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min') %>
+<%- js('https://7.url.cn/edu/jslib/comb/require-2.1.6,jquery-1.9.1.min') %>
 <script>
     var valueHide = "隐藏目录";
     var valueShow = "显示目录";

--- a/source/css/showshare.css
+++ b/source/css/showshare.css
@@ -1,4 +1,4 @@
-@import url(http://luuman.github.io/font-awesome/css/font-awesome.min.css);
+@import url(https://luuman.github.io/font-awesome/css/font-awesome.min.css);
 /*CSS源代码*/
 body {
     background: #CFCFCF;


### PR DESCRIPTION
github.io 域名现在默认用 https 了, http 协议的资源可能不会被浏览器加载.

HTTPS enforcement is required for GitHub Pages sites created after June 15, 2016 and using a github.io domain.
https://help.github.com/articles/securing-your-github-pages-site-with-https/
