### PR TITLE
修复显示代码框溢出问题，以及简单样式修改

### DIFF
--- a/source/css/_partial/highlight.styl
+++ b/source/css/_partial/highlight.styl
@@ -175,6 +175,7 @@ $line-numbers
     @extend $code-block
     border-radius: 4px
     padding: 0 10px
+    overflow: hidden
     pre
       border: none
       margin: 0
@@ -183,7 +184,7 @@ $line-numbers
       margin: 20px 0
       width: auto
       color: #FFF
-      thead 
+      thead
         tr
           background: #2D2D2D
         tr:hover
@@ -204,12 +205,15 @@ $line-numbers
     .gutter pre
       @extend $line-numbers
       text-align: right
-      padding-right: 20px
+      padding-right: 5px
+      margin-right: 10px
+      border-right: 2px solid gray
       .line
         text-shadow: none
     .line
       font-size: 15px
-      height: 15px
+      height: 20px
+      line-height: 20px
   .gist
     margin: 0 article-padding * -1
     border-style: solid


### PR DESCRIPTION
文章中的代码部分显示不完整，水平和竖直方向均出现滚动条，修复了此问题。

另外，代码部分行号与代码主题没有分隔，容易造成混淆，减小了间距并增加了分隔线。
