### PR TITLE
修复了代码块内左右和上下出现滚动条的问题

### DIFF
--- a/source/css/_partial/highlight.styl
+++ b/source/css/_partial/highlight.styl
@@ -163,7 +163,7 @@ $line-numbers
     content: attr(data-lang) " code"
     display: block
     background-color: #0083A0
-    margin: 0 -16px 16px -16px
+    margin: 0 -10px 16px -10px
     padding: 8px 16px
     color: #EFEFEF
     font-family: Lato,"Microsoft YaHei",sans-serif
@@ -209,7 +209,6 @@ $line-numbers
         text-shadow: none
     .line
       font-size: 15px
-      height: 15px
   .gist
     margin: 0 article-padding * -1
     border-style: solid


### PR DESCRIPTION
目前的样式 在Code域，拖动代码可以上下微小滚动，左右由于margin的缘故，出现了不应该有的左右滚动条
