### PR TITLE
使配置项中的inline-block和code-block生效

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,13 +81,13 @@ background:
   background_image: 109
 
 highlight_style:
-  #on: true
-  inline_code: 1  # Value: 0 - 9 可选
-  code_block: 1  # Value: 0 - 4 
+  on: true
+  inline_code: 7
+  code_block: 4
   # Set inline_code to style highlight text
   # Chose a highlight theme for code block
-  # 通过 inline_code 切换内置文本高亮样式
-  # 通过 code_block 切换内置代码高亮配色主题
+  # 通过 inline_code 切换内置文本高亮样式 Value: 0 - 9 可选
+  # 通过 code_block 切换内置代码高亮配色主题  Value: 0 - 4 
 
 blockquote_style:
   #on: true

--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -1,3 +1,4 @@
+@import "customise/inline-code"
 .body-wrap{
   margin-bottom: 80px;
 }
@@ -147,8 +148,10 @@
   p code,li code{
     padding: 1px 3px;
     margin: 0 3px;
-    background: #ddd;
-    border: 1px solid #ccc;
+	color: color-inline
+    background: color-inline-background;
+    border: 1px dashed color-inline-border-color;
+	border-radius: 3px;
     font-family: Menlo,Monaco,"Andale Mono","lucida console","Courier New",monospace;
     word-wrap: break-word;
     font-size: 14px;
@@ -251,6 +254,12 @@
         }
       }
     }
+  }
+  code{
+    color: color-inline;
+    background: color-inline-background;
+    padding: 1px 3px;
+    border-radius: 5px;
   }
 }
 

--- a/source/css/_partial/customise/code-block.styl
+++ b/source/css/_partial/customise/code-block.styl
@@ -20,8 +20,8 @@ code_block = hexo-config("highlight_style.code_block")
 if highlight_style
 
     // Tomorrow Night Eighties
-    if code_block
-        highlight-background   = rgba(51, 51, 51, .85)
+    if code_block == "1"
+        highlight-background   = #333333
         highlight-current-line = #393939
         highlight-selection    = #515151
         highlight-foreground   = #cccccc
@@ -36,7 +36,7 @@ if highlight_style
 
     // Tomorrow Night
     if code_block == "2"
-        highlight-background   = rgba(32, 34, 37, .85)
+        highlight-background   = #202225
         highlight-current-line = #282a2e
         highlight-selection    = #373b41
         highlight-foreground   = #c5c8c6
@@ -51,7 +51,7 @@ if highlight_style
 
     // Tomorrow Night Blue
     if code_block == "3"
-        highlight-background   = rgba(0, 40, 91, .8)
+        highlight-background   = #00285B
         highlight-current-line = #00346e
         highlight-selection    = #003f8e
         highlight-foreground   = #ffffff
@@ -66,7 +66,7 @@ if highlight_style
 
     // Tomorrow Night Bright
     if code_block == "4"
-        highlight-background   = rgba(0, 0, 0, .67)
+        highlight-background   = #000000
         highlight-current-line = #2a2a2a
         highlight-selection    = #424242
         highlight-foreground   = #eaeaea

--- a/source/css/_partial/customise/inline-code.styl
+++ b/source/css/_partial/customise/inline-code.styl
@@ -1,30 +1,31 @@
-.article-entry code
-    color gray
-    background rgba(248, 237, 223, .5)
-    padding .05em .3em
-    border-radius 3px
-    if highlight_style
-        var inline_code = hexo-config("highlight_style.inline_code")
-        color white
-        if !inline_code
-            color gray
-        if inline_code
-            background rgba(153, 204, 153, .7)
-        if inline_code == "2"
-            color #f48385
-            background rgba(199,38,79,0.07)
-        if inline_code == "3"
-            color gray
-            background rgba(255, 250, 165, .7)
-        if inline_code == "4"
-            background rgba(136, 172, 219, .65)
-        if inline_code == "5"
-            background rgba(239, 117, 34, .42)
-        if inline_code == "6"
-            background rgba(217, 83, 79, .45)
-        if inline_code == "7"
-            background rgba(129, 138, 145, .35)
-        if inline_code == "8"
-            background rgba(91, 192, 222, .6)
-        if inline_code == "9"
-            background rgba(250, 250, 250, .6)
+
+color-inline = #FFF
+color-inline-background = #002b36
+color-inline-border-color = #000
+
+
+inline_code = hexo-config("highlight_style.inline_code")
+if inline_code == "1"
+	color-inline = #FFF
+	color-inline-background = rgba(153, 204, 153, .7)
+	color-inline-border-color = #7EA299
+if inline_code == "2"
+	color-inline = #f48385
+	color-inline-background = rgba(199,38,79,0.07)
+if inline_code == "3"
+	color-inline = #FFF
+	color-inline-background = rgba(255, 250, 165, .7)
+if inline_code == "4"
+	color-inline-background = rgba(136, 172, 219, .65)
+if inline_code == "5"
+	color-inline-background = rgba(239, 117, 34, .42)
+if inline_code == "6"
+	color-inline-background = rgba(217, 83, 79, .45)
+if inline_code == "7"
+	color-inline-background = rgba(129, 138, 145, .35)
+if inline_code == "8"
+	color-inline-background = rgba(91, 192, 222, .6)
+if inline_code == "9"
+	color-inline-background = rgba(250, 250, 250, .6)
+    
+    

--- a/source/css/_partial/highlight.styl
+++ b/source/css/_partial/highlight.styl
@@ -1,14 +1,16 @@
 // https://github.com/luuman/hexo-theme-spfk
 
-code-bgc = #002B36
-code-tag = #F92672
-code-attr = #A6E22E
-code-word = #FFFFFF
-code-value = #E6DB74
-code-number = #9E90FF
-code-keyword = #66D9EF
-code-comment = #75715E
-code-argument = #FD971F
+@import "_partial/customise/code-block"
+
+code-bgc = highlight-background
+code-tag = highlight-yellow 
+code-attr = highlight-blue
+code-word = highlight-foreground
+code-value = highlight-green
+code-number = highlight-aqua
+code-keyword = highlight-purple
+code-comment = highlight-comment
+code-argument = highlight-orange
 
 $code-block
   background: code-bgc
@@ -19,7 +21,7 @@ $code-block
   line-height: font-size * line-height
 
 $line-numbers
-  color: #999
+  color: code-number
 
 .article-entry
   pre, code
@@ -37,7 +39,7 @@ $line-numbers
     -moz-box-sizing: border-box
     box-sizing: border-box
   code
-    background: color-background
+    background: color-inline-background
     padding: 0 0.3em
     border: none
   pre
@@ -52,14 +54,14 @@ $line-numbers
     code
       margin: 0 3px
       border: dashed 1px #000
-      color: #FFF
+      color: color-inline
       padding: 1px 8px
       font-size: 90%
       -webkit-border-radius: 5px
       border-radius: 5px
       font-family: Consolas,"Courier New",Courier
       text-shadow: none
-      background-color: #002B36
+      background-color: color-inline-background
       word-wrap: break-word
       white-space: pre
     a
@@ -209,6 +211,7 @@ $line-numbers
         text-shadow: none
     .line
       font-size: 15px
+	  color: highlight-foreground
   .gist
     margin: 0 article-padding * -1
     border-style: solid
@@ -255,7 +258,7 @@ pre
     color: #839496
   .title
     color: #66D9EF
-  .strings
+  .string
     color: #2aa198
   .attribute
     color: #b58900
@@ -273,7 +276,7 @@ pre
   .params
   .function
   .css .value
-    color: code-word
+    color: code-argument
   .css ~ * .tag
   .at_rule
   .preprocessor

--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -18,6 +18,8 @@ color-facebook = #3b5998
 color-pinterest = #cb2027
 color-google = #dd4b39
 
+
+
 // Fonts
 font-chs = "Microsoft YaHei", "Hiragino Sans GB", "WenQuanYi Micro Hei", sans-serif
 font-sans = "Lucida Grande", Verdana, "Helvetica Neue", Arial, sans-serif

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -10,7 +10,6 @@
   font-weight:normal;
   font-style:normal
 }
-
 global-reset()
 
 ol{


### PR DESCRIPTION
## 修改了部分代码，使得主题切换得以生效
- 当值设置在0或者合法值以外时，采用默认主题
- 统一了inline-code时 li下的code标签和pre下的code标签的表现，使其表现统一
